### PR TITLE
optional context menu grouping

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -69,30 +69,62 @@ export default class StyleText extends Plugin {
 	}
 
 	styleTextInContextMenu = (menu: Menu, editor: Editor) => {
-		const enhancedApp = this.app as EnhancedApp;
+    const enhancedApp = this.app as EnhancedApp;
 
-		menu.addItem((item) =>
-			item
-				.setTitle("Remove Style")
-				.setIcon("eraser")
-				.onClick(() => {
-					enhancedApp.commands.executeCommandById(`style-text:remove-style`);
-				})
-		);
+    menu.addItem((item) =>
+        item
+            .setTitle("Remove Style")
+            .setIcon("eraser")
+            .onClick(() => {
+                enhancedApp.commands.executeCommandById(`style-text:remove-style`);
+            })
+    );
 
-		this.settings.styles.forEach((style, index) => {
-			if (style.contextMenu) {
-				menu.addItem((item) =>
-					item
-						.setTitle(style.name)
-						.setIcon("highlighter")
-						.onClick(() => {
-							enhancedApp.commands.executeCommandById(`style-text:style${index + 1}`);
-						})
-				);
-			}
-		});
+    const addStyleItems = (submenu: Menu) => {
+        this.settings.styles.forEach((style, index) => {
+            if (style.contextMenu) {
+                submenu.addItem((item) =>
+                    item
+                        .setTitle(style.name)
+                        .setIcon("highlighter")
+                        .onClick(() => {
+                            enhancedApp.commands.executeCommandById(`style-text:style${index + 1}`);
+                        })
+                );
+            }
+        });
+    };
+
+		if (this.settings.groupContextMenu) {
+			menu.addItem((item) => {
+					item.setTitle("Style selected text")
+							.setIcon("highlighter");
+					
+					// @ts-ignore
+					item.setSubmenu();
+	
+					const submenu = new Menu();
+					this.settings.styles.forEach((style, index) => {
+							if (style.contextMenu) {
+									submenu.addItem((subItem) =>
+											subItem
+													.setTitle(style.name)
+													.setIcon("highlighter")
+													.onClick(() => {
+															enhancedApp.commands.executeCommandById(`style-text:style${index + 1}`);
+													})
+									);
+							}
+					});
+					// @ts-ignore
+					item.submenu = submenu;
+			});
+	} else {
+			addStyleItems(menu);
 	}
+	
+};
+
 
 	updateBodyListClass() {
 		document.body.classList.add("style-text");

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { ButtonComponent, PluginSettingTab, Setting } from "obsidian";
+import { ButtonComponent, PluginSettingTab, Setting, ToggleComponent } from "obsidian";
 import StyleText from './main';
 export interface Style {
 	name: string;
@@ -6,10 +6,12 @@ export interface Style {
 	contextMenu: boolean;
 }
 export interface StyleTextSettings {
+	groupContextMenu: boolean;
 	styles: Style[];
 }
 
 export const DEFAULT_SETTINGS: StyleTextSettings = {
+	groupContextMenu: false,
 	styles: [
 		{ name: "Super Big", css: "font-size: 28px;", contextMenu: true },
 		{ name: "Super Big Yellow Highlight", css: "font-size: 28px; background-color: #fff88f; color: black", contextMenu: false },
@@ -56,7 +58,21 @@ export class GeneralSettingsTab extends PluginSettingTab {
 		addStyleButton.onclick = ev => this.addStyle(settingContainer);
 
 		this.plugin.settings.styles.forEach((s, i) => this.addStyle(settingContainer, i + 1));
-
+		
+		const groupSettingContainer = containerEl.createDiv({ cls: 'setting-item group-context-menu-setting' });
+		groupSettingContainer.style.cssText = 'display: flex; justify-content: space-between; align-items: center;';
+		
+		const infoContainer = groupSettingContainer.createDiv({ cls: 'setting-item-info' });
+		infoContainer.createEl('div', { cls: 'setting-item-name', text: 'Group context menu' });
+		infoContainer.createEl('div', { cls: 'setting-item-description', text: 'Combine styles into a submenu in the context menu' });
+		
+		new ToggleComponent(groupSettingContainer.createDiv({ cls: 'setting-item-control' }))
+				.setValue(this.plugin.settings.groupContextMenu)
+				.onChange(async (value) => {
+						this.plugin.settings.groupContextMenu = value;
+						await this.plugin.saveSettings();
+				});
+		
 		this.addInstructions(containerEl);
 
 		this.donate(containerEl);
@@ -65,18 +81,18 @@ export class GeneralSettingsTab extends PluginSettingTab {
 
 	private clearHtml() {
 		// remove disruptive classes and elements
-		setTimeout(() => {
-			removeClass("setting-item");
-			removeClass("setting-item-info");
-			removeClass("setting-item-control");
-			deleteContainer(".setting-item-description");
-		}, 0);
-
-		function removeClass(className: string) {
-			document.querySelectorAll("." + className)
-				.forEach(i => i.removeClass(className));
-		}
-
+			setTimeout(() => {
+					removeClass("setting-item", ".group-context-menu-setting");
+					removeClass("setting-item-info", ".group-context-menu-setting");
+					removeClass("setting-item-control", ".group-context-menu-setting");
+					deleteContainer(".setting-item-description:not(.group-context-menu-setting .setting-item-description)");
+			}, 0);
+	
+			function removeClass(className: string, excludeSelector: string) {
+					document.querySelectorAll(`.${className}:not(${excludeSelector})`)
+							.forEach(i => i.removeClass(className));
+			}
+	
 		function deleteContainer(selector: string) {
 			document.querySelectorAll(selector)
 				.forEach(i => i.parentElement?.remove());


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6a814c7e-de4c-4369-bee7-00dd300cab86)
![image](https://github.com/user-attachments/assets/e1c09d5a-ada1-42d5-b5eb-7c61ddb323fd)

screenshots explains it perfectly ;)

I found it pretty useful - not thoroughly tested, but pretty simple code 

had to figure out how to use the excluded settings classes without clashing with the intentional removal of those and it works
additionally ts didn't really like the non-existence of the submenu ... also not really sure if its done like I did by creating a new menu as a submenu, but it does work just fine as I've tested it also with other plugins which add context menu entries and obviously those do not clash - seems to work without issues ... ofc feel free improving (especially if there are issues)

if having any issues with it post a issue on my fork or if posting here on upstream repo feel free pinging me and I'll see what I can do if I'm able to reproduce the possible issue